### PR TITLE
Editorial nits

### DIFF
--- a/draft-massimo-dilithium-pkix-00.xml
+++ b/draft-massimo-dilithium-pkix-00.xml
@@ -112,9 +112,9 @@
       <name>Introduction</name>
       <!-- EDNOTE: Could put in the classic introduction to why we need PQ crypto, but I don't think it is needed, we don't need to convince people why PQ is important here, nist has standardized it and we are just defining how to use it-->
 
-      <t>The US National Institute of Standards and Technology (NIST) Post-Quantum Cryptography (PQC) effort has defined quantum-resistant public-key cryptographic algorithm standards <xref target="NIST-PQC" format="default"></xref>. This document specifies the use of these Post-Quantum public key algorithms with Public Key Infrastructure X.509 (PKIX) certificates and Certificate Revocation Lists (CRLs) using object identifiers algorithms assigned by NIST.</t>
+      <t>The US National Institute of Standards and Technology (NIST) Post-Quantum Cryptography (PQC) effort has defined quantum-resistant public key cryptographic algorithm standards <xref target="NIST-PQC" format="default"></xref>. This document specifies the use of these Post-Quantum public key algorithms with Public Key Infrastructure X.509 (PKIX) certificates and Certificate Revocation Lists (CRLs) using object identifiers algorithms assigned by NIST.</t>
       
-      <t>This document specifies the conventions for the signatureAlgorithm, signatureValue, signature, and subjectPublicKeyInfo fields within Internet X.509 certificates and CRLs <xref target="RFC5280" format="default"></xref> like <xref target="RFC3279" format="default"></xref> did for classic cryptography and <xref target="RFC5480" format="default"></xref> did for elliptic curve cryptography. It describes the encoding of digital signatures and public generated with quantum-resistant signature algorithm Dilithium.</t>
+      <t>This specification includes conventions for the signatureAlgorithm, signatureValue, signature, and subjectPublicKeyInfo fields within Internet X.509 certificates and CRLs <xref target="RFC5280" format="default"></xref>, like <xref target="RFC3279" format="default"></xref> did for classic cryptography and <xref target="RFC5480" format="default"></xref> did for elliptic curve cryptography. It describes the encoding of digital signatures and public keys generated with quantum-resistant signature algorithm Dilithium.</t>
 
       <!-- [PK]: No digests here since they are included in the PQ sig. -->
       <!-- <t>This document also identifies additional one-way hash functions for use in the generation of quantum-safe digital signatures. These algorithms are used in conjunction with digital signature algorithms, and supplement those described within RFC 3279, RFC 5758, and RFC 8692.</t>-->
@@ -123,7 +123,7 @@
         <name>Requirements Language</name>
         <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
        "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-       document are to be interpreted as described in BCP 14 <xref target="RFC2119" format="default">RFC 2119</xref>
+       document are to be interpreted as described in BCP 14 <xref target="RFC2119" />
        <xref target="RFC8174" /> when, and only when, they appear in all capitals, as shown here.</t>
       </section> <!-- End of Requirements Language Section -->
 
@@ -133,7 +133,7 @@
     <section numbered="true" toc="default" anchor="oids">
       <name>Identifiers</name>
 
-      <t>This specification uses object identifiers for the new algorithms that are assigned by NIST, and will use placeholders until these are released.</t>
+      <t>This specification uses placeholders for object identifiers until the identifiers for the new algorithms are assigned by NIST.</t>
       
       <t>The AlgorithmIdentifier type, which is included herein for convenience, is defined as follows: </t>
 
@@ -150,9 +150,9 @@
 
       <t>The OIDs are:</t>
       <sourcecode type="asn.1" markers="false" pn="section2-1">
-   id-dilithiumTBD-shake256 OBJECT IDENTIFIER ::= { joint-iso-itu-t(2) 
-            country(16) us(840) organization(1) gov(101) csor(3) 
-            nistAlgorithm(4) hashAlgs(2) TBD }     
+   id-dilithiumTBD-shake256 OBJECT IDENTIFIER ::= {
+            joint-iso-itu-t(2) country(16) us(840) organization(1)
+            gov(101) csor(3) nistAlgorithm(4) hashAlgs(2) TBD }
       </sourcecode>
       
        <t>The contents of the parameters component for each algorithm are absent.</t>
@@ -164,7 +164,7 @@
       <name>One-Way Hash Functions</name>
       <t>This sections identifies five additional hash algorithms for use with post-quantum digital signature algorithms in the Internet X.509 certificate and CRL profile. The hash functions SHA3-256, SHA3-384, SHA3-512 produce 256-bit, 384-bit and 512-bit "hash" of the input, respectively, and are fully described in the "Secure Hash Standard" <xref target="FIPS202" format="default"></xref>. The extendable-output functions SHAKE-128 and SHAKE-256 provide extendable (and thus variable) output sizes and are also fully described in the "Secure Hash Standard" <xref target="FIPS202" format="default"></xref>.</t>
 
-      <t>When one of these OIDs appears in an AlgorithmIdentifier, all implementations MUST accept both NULL and absent parameters as legal and equivalent encodings.</t>
+      <t>When one of these OIDs appears in an AlgorithmIdentifier, all implementations <bcp14>MUST</bcp14> accept both NULL and absent parameters as legal and equivalent encodings.</t>
 
       <t>Conforming certification authority (CA) implementations SHOULD use SHA3-256, SHA3-384, SHA3-512, SHAKE-128 or SHAKE-256 when generating quantum-secure certificates or CRLs.</t>
 
@@ -199,7 +199,7 @@
         <section numbered="true" toc="default">
          <name>Dilithium Signatures in PKIX</name>
         
-         <t>Dilithium is a digital signature scheme built upon the Fiat-Shamir with aborts framework <xref target="Fiat-Shamir" format="default"></xref>. The security is based upon the hardness of lattice problems over module lattices <xref target="Dilithium" format="default"></xref>. Dilithium provides 3 parameter sets for the security categories 2, 3 and 5.</t>
+         <t>Dilithium is a digital signature scheme built upon the Fiat-Shamir-with-aborts framework <xref target="Fiat-Shamir" format="default"></xref>. The security is based upon the hardness of lattice problems over module lattices <xref target="Dilithium" format="default"></xref>. Dilithium provides three parameter sets for the security categories 2, 3 and 5.</t>
 
           <t>Signatures are used in a number of different ASN.1 structures.
           As shown in the ASN.1 representation from <xref target="RFC5280" format="default" sectionFormat="of" derivedContent="RFC5280"/> 
@@ -224,13 +224,13 @@
       signatureValue       BIT STRING  }
         </sourcecode>
 
-        <t>The identifiers defined in <xref target="oids" format="default"/> can be used as the AlgorithmIdentifier in the signatureAlgorithm field in the sequence Certificate/CertificateList and the signature field in the sequence TBSCertificate/TBSCertList in certificates CRLs, respectively,<xref target="RFC5280" format="default"/>. The parameters of these signature algorithms are absent, as explained in <xref target="oids" format="default" sectionFormat="of" derivedContent="Section 3"/>.</t>
+        <t>The identifiers defined in <xref target="oids" format="default"/> can be used as the AlgorithmIdentifier in the signatureAlgorithm field in the sequence Certificate/CertificateList and the signature field in the sequence TBSCertificate/TBSCertList in certificates CRLs, respectively, <xref target="RFC5280" format="default"/>. The parameters of these signature algorithms are absent, as explained in <xref target="oids" format="default" sectionFormat="of" derivedContent="Section 3"/>.</t>
         
         <t>The signatureValue field contains the corresponding Dilithium signature computed upon the ASN.1 DER encoded tbsCertificate <xref target="RFC5280" format="default"/>.</t>
         
         <t>Conforming Certification Authority (CA) implementations <bcp14>MUST</bcp14> specify the algorithms explicitly by using the OIDs specified in <xref target="oids" format="default" sectionFormat="of" derivedContent="Section 3"/> when encoding Dilithium signatures in certificates and CRLs. Conforming client implementations that process certificates and CRLs using Dilithium <bcp14>MUST</bcp14> recognize the corresponding OIDs. Encoding rules for Dilithium signature values are specified <xref target="oids" format="default" sectionFormat="of" derivedContent="Section 3"/>.</t>
 
-          <t>When the id-dilithiumTBD-shake256 identifier appears in the algorithm field as an AlgorithmIdentifier, the encoding MUST omit the parameters field. That is, the AlgorithmIdentifier SHALL be a SEQUENCE of one component, the OID id-dilithiumTBD-shake256.</t>
+          <t>When the id-dilithiumTBD-shake256 identifier appears in the algorithm field as an AlgorithmIdentifier, the encoding <bcp14>MUST</bcp14> omit the parameters field. That is, the AlgorithmIdentifier <bcp14>SHALL</bcp14> be a SEQUENCE of one component, the OID id-dilithiumTBD-shake256.</t>
         </section> <!-- End of Dilithium Signatures in PKIX Section -->
 
 
@@ -259,6 +259,7 @@
   </sourcecode>
          
          <t>The public parameters for Dilithium are based upon a polynomial ring R_q for prime q. A (k*l) public matrix A is produced, consisting of polynomials whose coefficients are sampled uniformly at random from the integers modulo q. This sampling is performed by expanding a nonce rho using an XOF.</t> <!--- [JM]This could be too much detail (I think it is) but otherwise if feels like are plucking letters out of the air. I guess we pluck p and q out of the air in the original RSA/DH spec, but because there are so many more letters in Dilithium, it feels worse. This is the most brief of an explanation I could give for where rho, and k come from. --> 
+         <!--- [EC]I found the sentence about "rho" very hard to read. Something like "expanding a nonce (rho) using..." could help. I also found the "(k*l) public matrix" hard to read because of how 'l' is rendered. It's also not referenced in this section anywhere (it doesn't affect the size of the public key??), but it does make an appearance in the appendix. -->
          <t>The Dilithium public key <bcp14>MUST</bcp14> be encoded using the ASN.1 type DilithiumPublicKey:</t>
          
                 <!---<ul spacing="compact">
@@ -285,7 +286,7 @@
        <sourcecode type="asn.1" markers="false" pn="section">
   DilithiumPublicKey ::= OCTET STRING
       </sourcecode> 
-         <t>where DilithiumPublicKey is a concatenation of rho and t1. Here, rho is the nonce used to seed the XOF to produce the matrix A, and t1 is a vector encoded in 320*k bytes where k is the rank of the vector over the polynomial ring R_q. These parameters MUST be encoded as a single OCTET STRING. The size required to hold a DilithiumPublicKey public key element is therefore 32+320*k bytes.</t>
+         <t>where DilithiumPublicKey is a concatenation of rho and t1. Here, rho is the nonce used to seed the XOF to produce the matrix A, and t1 is a vector encoded in 320*k bytes where k is the rank of the vector over the polynomial ring R_q. These parameters <bcp14>MUST</bcp14> be encoded as a single OCTET STRING. The size required to hold a DilithiumPublicKey public key element is therefore 32+320*k bytes.</t>
 
           <!-- do we need to include this? I'm basing this on the original RFC 3279 which did this for ECC https://datatracker.ietf.org/doc/html/rfc3279#section-2.3.3-->
         <!-- [PK] In the past using parameters in OIDs have caused all types of issues. Nowadays the IETF hardcodes all parameters to the OID. For example OID XYZ gives everything needed for the algorithm like security level, hash algorithm key sizes etc. --> 
@@ -301,7 +302,7 @@
                <artwork name="" type="" align="left" alt=""><![CDATA[
 id-securityLevel OBJECT IDENTIFIER ::= { XXXX-XX-XX securityLevel(X) }]]>
                 </artwork> 
-      <t> When the parameters are inherited, the parameters field SHALL contain implictlyCA, which is the ASN.1 value NULL. When parameters are specified by reference, the parameters field SHALL contain the security level choice, which is an object identifier.  When the parameters are explicitly included, they SHALL be encoded in the ASN.1 structure DilithiumParameters:</t>
+      <t> When the parameters are inherited, the parameters field <bcp14>SHALL</bcp14> contain implictlyCA, which is the ASN.1 value NULL. When parameters are specified by reference, the parameters field <bcp14>SHALL</bcp14> contain the security level choice, which is an object identifier.  When the parameters are explicitly included, they <bcp14>SHALL</bcp14> be encoded in the ASN.1 structure DilithiumParameters:</t>
       <sourcecode type="asn.1" markers="false" pn="section-5">
   DilithiumParameters ::= SEQUENCE {
       n        INTEGER,    the dimension of the polynomial ring R_q
@@ -317,11 +318,11 @@ id-securityLevel OBJECT IDENTIFIER ::= { XXXX-XX-XX securityLevel(X) }]]>
 <!-- EDNOTE: I dont know what data type all those variables should be, between integers, octet strings or bit strings. could also break them out even further into more objects -->
 
          <!-- [PK]: Commenting out as I think this goes back to the hardcoded parameters and is unecessary --> 
-         <!--<t>The AlgorithmIdentifier within SubjectPublicKeyInfo is the only place within a certificate where the parameters may be used. If the Dilithium parameters are specified as implicitlyCA in the SubjectPublicKeyInfo AlgorithmIdentifier and the CA signed the subject certificate using Dilithium, then the certificate issuer's Dilithium parameters apply to the subject's Dilithium key. If the Dilithium  parameters are specified as implicitlyCA in the SubjectPublicKeyInfo AlgorithmIdentifier and the CA signed the certificate using a signature algorithm other than Dilithium, then clients MUST not make use of the Dilithium public key.</t>-->
+         <!--<t>The AlgorithmIdentifier within SubjectPublicKeyInfo is the only place within a certificate where the parameters may be used. If the Dilithium parameters are specified as implicitlyCA in the SubjectPublicKeyInfo AlgorithmIdentifier and the CA signed the subject certificate using Dilithium, then the certificate issuer's Dilithium parameters apply to the subject's Dilithium key. If the Dilithium  parameters are specified as implicitlyCA in the SubjectPublicKeyInfo AlgorithmIdentifier and the CA signed the certificate using a signature algorithm other than Dilithium, then clients <bcp14>MUST</bcp14> not make use of the Dilithium public key.</t>-->
 
-         <t>The id-dilithiumTBD-shake256 identifier defined in <xref target="oids"/> MUST be used as the algorithm field in the SubjectPublicKeyInfo sequence <xref target="RFC5280" format="default"/> to identify a Dilithium public key.</t>
+         <t>The id-dilithiumTBD-shake256 identifier defined in <xref target="oids"/> <bcp14>MUST</bcp14> be used as the algorithm field in the SubjectPublicKeyInfo sequence <xref target="RFC5280" format="default"/> to identify a Dilithium public key.</t>
          
-         <t>The intended application for the key is indicated in the keyUsage certificate extension; see <xref target="RFC5280" sectionFormat="of" section="4.2.1.3"/>. If the keyUsage extension is present in a certificate that indicates id-dilithiumTBD-shake256 in the SubjectPublicKeyInfo, then the at least one of following MUST be present:</t>
+         <t>The intended application for the key is indicated in the keyUsage certificate extension; see <xref target="RFC5280" sectionFormat="of" section="4.2.1.3"/>. If the keyUsage extension is present in a certificate that indicates id-dilithiumTBD-shake256 in the SubjectPublicKeyInfo, then the at least one of following <bcp14>MUST</bcp14> be present:</t>
 <artwork><![CDATA[
   digitalSignature; or
   nonRepudiation; or
@@ -330,7 +331,7 @@ id-securityLevel OBJECT IDENTIFIER ::= { XXXX-XX-XX securityLevel(X) }]]>
 ]]></artwork>
          <t>Requirements about the keyUsage extension bits defined in <xref target="RFC5280" format="default"/> still apply.</t>
          
-         <t>Conforming CA implementations MUST specify the X.509 public key algorithm explicitly by using the OIDs specified in this specification when Dilithium public keys in certificates and CRLs. Conforming client implementations that process Dilithium public keys when processing certificates and CRLs MUST recognize the corresponding OIDs. </t>
+         <t>Conforming CA implementations <bcp14>MUST</bcp14> specify the X.509 public key algorithm explicitly by using the OIDs specified in <xref target="oids"/> when using Dilithium public keys in certificates and CRLs. Conforming client implementations that process Dilithium public keys when processing certificates and CRLs <bcp14>MUST</bcp14> recognize the corresponding OIDs. </t>
 
         </section>  <!-- End of Dilithium Public Keys in PKIX Section -->
 
@@ -457,16 +458,18 @@ id-securityLevel OBJECT IDENTIFIER ::= { XXXX-XX-XX securityLevel(X) }]]>
       <!--<t>TODO: Add discussion about digests in classical signatures hash-then-sign and how that does not apply to PQ like Dilithium. And how committing to a message is additional security. Reference NIST discussion from Peiker and Makku.</t>-->
       <t>EDNOTE: Discuss implications of not hash-then-sign. Implications in performance too.</t>
       <!-- [JM] Small note on hash-then-sign. Dilithium (see fig 4 line 10 of https://pq-crystals.org/dilithium/data/dilithium-specification-round3.pdf) " Our full scheme in Fig. 4 also makes use of basic optimizations such as pre-hashing the message M so as to not rehash it with every signing attempt." -->
-      <t>Within the hash-then-sign paradigm, hash functions are used as a domain restrictor over the message to be signed. By pre-hashing, the onus of resistance to existential forgeries becomes heavily reliant on the collision-resistance of the hash function in use. As well as this security goal, the hash-then-sign paradigm also has the ability to improve performance by reducing the size of signed messages. As a corollary, hashing remains mandatory even for short messages and assigns a further computational requirement onto the verifier. This makes the performance of hash-then-sign schemes more consistent, but not necessarily more efficient. Dilithium diverges from the hash-then-sign paradigm by hashing the message during the signing procedure (at the point in which the challenge polynomial). However, due to the fact that Dilithium signatures may require the signing procedure to be repeated several times for a signature to be produced, Dilithium implementations can make use of pre-hashing the message to prevent rehashing with each attempt.</t>
+      <t>Within the hash-then-sign paradigm, hash functions are used as a domain restrictor over the message to be signed. By pre-hashing, the onus of resistance to existential forgeries becomes heavily reliant on the collision-resistance of the hash function in use. As well as this security goal, the hash-then-sign paradigm also has the ability to improve performance by reducing the size of signed messages. As a corollary, hashing remains mandatory even for short messages and assigns a further computational requirement onto the verifier. This makes the performance of hash-then-sign schemes more consistent, but not necessarily more efficient. Dilithium diverges from the hash-then-sign paradigm by hashing the message
+      <!-- [EC] Something is wrong with "(at the point in which the challenge polynomial)"  -->
+      during the signing procedure (at the point in which the challenge polynomial). However, due to the fact that Dilithium signatures may require the signing procedure to be repeated several times for a signature to be produced, Dilithium implementations can make use of pre-hashing the message to prevent rehashing with each attempt.</t>
 
       <t>EDNOTE: Discuss side-channels for Dilithium. .</t>
-      <t>Dilithium has been designed with an aim to provide side-channel resilience by eliminating a reliance on Gaussian sampling. While deliberate design decisions such as these can help to deliver a greater ease of secure implementation - particularly against side-channel attacks - it does not necessarily provide resistance to more powerful attacks such as differential power analysis. Some amount of side-channel leakage has been demonstrated in parts of the signing algorithm (specifically the bit-unpacking function), from which a demonstration of key recovery has been made over a large sample of signatures. Masking countermeasures exist for Dilithium<!--[MGTF19]-->, but come with a performance overhead.</t>
+      <t>Dilithium has been designed to provide side-channel resilience by eliminating a reliance on Gaussian sampling. While deliberate design decisions such as these can help to deliver a greater ease of secure implementation - particularly against side-channel attacks - it does not necessarily provide resistance to more powerful attacks such as differential power analysis. Some amount of side-channel leakage has been demonstrated in parts of the signing algorithm (specifically the bit-unpacking function), from which a demonstration of key recovery has been made over a large sample of signatures. Masking countermeasures exist for Dilithium<!--[MGTF19]-->, but come with a performance overhead.</t>
 
       <t>A fundamental security property also associated with digital signatures is non-repudiation. Non-repudiation refers to the assurance that the owner of a signature key pair that was capable of generating an existing signature corresponding to certain data cannot convincingly deny having signed the data. The digital signature scheme Dilithium possess three security properties beyond unforgeability, that are associated with non-repudiation. These are exclusive ownership, message-bound signatures, and non-resignability. These properties are based tightly on the assumed collision resistance of the hash function used (in this case SHAKE-256).
 
       Exclusive ownership is a property in which a signature sigma uniquely determines the public key and message for which it is valid. Message-bound signatures is the property that a valid signature uniquely determines the message for which it is valid, but not necessarily the public key. Non-resignability is the property in which one cannot produce a valid signature under another key given a signature sigma for some unknown message m. These properties are not provided by classical signature schemes such as DSA or ECDSA, and have led to a variety of attacks such as Duplicate-Signature Key Selection (DSKS) attacks <!--[BWM99, MS04]-->, and attacks on the protocols for secure routing<!--[JCCS19]-->. A full discussion of these properties in Dilithium can be found at <xref target="CDFFJ21" format="default"></xref>.
 
-      These properties are dependent in part, on unambiguous public key serialization. It for this reason the public key structure defined in <xref target="dilithiumpublickey" format="default"/> are intentionally encoded as a single OCTET STRING.</t>
+      These properties are dependent, in part, on unambiguous public key serialization. It for this reason the public key structure defined in <xref target="dilithiumpublickey" format="default"/> is intentionally encoded as a single OCTET STRING.</t>
 
 
     </section>  <!-- End of Security Considerations Section -->


### PR DESCRIPTION
This PR contains a few edits for clarity and consistency (e.g., using `<bcp14> tags consistently, consistent hyphenation of "public key" in text). It also fixes a few typos (missing words, commas, and spaces), and two `xml2rfc` warnings about overly-long lines.

My only major comments are about the mathematical description of Dilithium in section 4, which I found difficult to read. Comments in-line.